### PR TITLE
avoid to record tracing headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,11 +73,6 @@ module.exports = function (host, opts) {
       // in the original request. It might be different between local development and ci envs.
       req.headers['host'] = 'un-qualsiasi-host';
 
-	  // avoid to store the request id
-	  delete req.headers['x-dl-request-id'];
-	  // avoid to store tracing includes
-	  delete req.headers['x-amzn-trace-id'];
-
       var file = path.join(opts.dirname, currentNamespace, tapename(req, body));
       debug('req / file:', req.url, file);
 

--- a/src/tape.ejs
+++ b/src/tape.ejs
@@ -28,7 +28,7 @@ var path = require("path");
 module.exports = function (req, res) {
   res.statusCode = <%- JSON.stringify(res.statusCode) %>;
 
-<% Object.keys(res.headers).forEach(function (key) { -%>
+<% Object.keys(res.headers).filter(function (key){ return !['x-dl-request-id','x-amzn-trace-id'].includes(key)}).forEach(function (key) { -%>
   res.setHeader(<%- JSON.stringify(key) %>, <%- JSON.stringify(res.headers[key]) %>);
 <% }); -%>
 


### PR DESCRIPTION
we can't record tracing header because they change every time, we create a middleware that capture the trace id and set it to the response; in order to do this we want to avoid to record those header in the tape